### PR TITLE
Ome tiff compression

### DIFF
--- a/src/test/java/explore/WriteMultiResolutionTiff.java
+++ b/src/test/java/explore/WriteMultiResolutionTiff.java
@@ -21,8 +21,8 @@ public class WriteMultiResolutionTiff
 		String in = WriteMultiResolutionTiff.class.getResource(
 				"../MultiResolutionTiff/image.tif").getFile();
 
-		String out =  "/Users/tischer/Documents/fiji-plugin-plateViewer/src/test/resources/MultiResolutionTiff"
-				+ File.separator + "image-scale2res4-uncompressed.tif";
+		String out =  "src/test/resources/MultiResolutionTiff"
+				+ File.separator + "image-scale2res4-lzw.ome.tif";
 
 		int scale = 2;
 		int resolutions = 4;

--- a/src/test/java/explore/WriteMultiResolutionTiff.java
+++ b/src/test/java/explore/WriteMultiResolutionTiff.java
@@ -48,11 +48,8 @@ public class WriteMultiResolutionTiff
 		IFormatWriter writer = new ImageWriter();
 		writer.setMetadataRetrieve(meta);
 		writer.setId(out);
-		writer.saveBytes(0, img);
-		// TODO: Does not seem to work...
 		writer.setCompression( TiffWriter.COMPRESSION_LZW );
-//		writer.setCompression( TiffWriter.COMPRESSION_UNCOMPRESSED );
-//
+		writer.saveBytes(0, img);
 		int type = reader.getPixelType();
 		for (int i=1; i<resolutions; i++) {
 			writer.setResolution(i);


### PR DESCRIPTION
Fixes #4 and #5

- since the example is using `ImageWriter` which is using the output file extension to choose the writer, the `.ome.tif[f]` suffix is necessary to write data as pyramidal OME-TIFF rather than plain TIFF
- sets compression before saving the bytes

With the two commits, running

```
$ mvn test
$ mvn exec:java -Dexec.mainClass="explore.WriteMultiResolutionTiff" -Dexec.classpathScope="test"
```

the generated output TIFF has one main IFD with three subIFDs (for each sub-resolutions) and using the LZW compression scheme

```
sbesson@ls30630:fiji-plugin-plateViewer (ome_tiff_compression) $ tiffinfo src/test/resources/MultiResolutionTiff/image-scale2res4-lzw.ome.tif 
TIFF Directory at offset 0x8 (8)
  Image Width: 1608 Image Length: 1608
  Resolution: 0, 0 pixels/cm
  Bits/Sample: 16
  Sample Format: unsigned integer
  Compression Scheme: LZW
  Photometric Interpretation: min-is-black
  Samples/Pixel: 1
  Rows/Strip: 1
  Planar Configuration: single image plane
  SubIFD Offsets: 2498334 3170687 3363739
  ImageDescription: <?xml version="1.0" encoding="UTF-8" standalone="no"?><!-- Warning: this comment is an OME-XML metadata block, which contains crucial dimensional parameters and other important metadata. Please edit cautiously (if at all), and back up the original data before doing so. For more information, see the OME-TIFF web site: https://docs.openmicroscopy.org/latest/ome-model/ome-tiff/. --><OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Creator="OME Bio-Formats 6.1.0-m1" UUID="urn:uuid:0c9a2b95-d11d-483e-be40-b9c5636c3a0c" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"><Image ID="Image:0" Name="image.tif"><Description/><Pixels BigEndian="true" DimensionOrder="XYCZT" ID="Pixels:0" Interleaved="false" SignificantBits="16" SizeC="1" SizeT="1" SizeX="1608" SizeY="1608" SizeZ="1" Type="uint16"><Channel ID="Channel:0:0" SamplesPerPixel="1"><LightPath/></Channel><TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1"><UUID FileName="image-scale2res4-lzw.ome.tif">urn:uuid:0c9a2b95-d11d-483e-be40-b9c5636c3a0c</UUID></TiffData></Pixels></Image><StructuredAnnotations><MapAnnotation ID="Annotation:Resolution:0" Namespace="openmicroscopy.org/PyramidResolution"><Value><M K="1">804 804</M><M K="2">402 402</M><M K="3">201 201</M></Value></MapAnnotation></StructuredAnnotations></OME>
  Software: OME Bio-Formats 6.1.0-m1
sbesson@ls30630:fiji-plugin-plateViewer (ome_tiff_compression) $ showinf -nopix -noflat src/test/resources/MultiResolutionTiff/image-scale2res4-lzw.ome.tif 
Checking file format [OME-TIFF]
Initializing reader
OMETiffReader initializing src/test/resources/MultiResolutionTiff/image-scale2res4-lzw.ome.tif
Reading IFDs
Populating metadata
Initialization took 0.079s

Reading core metadata
filename = /private/tmp/fiji-plugin-plateViewer/src/test/resources/MultiResolutionTiff/image-scale2res4-lzw.ome.tif
Used files = [/private/tmp/fiji-plugin-plateViewer/src/test/resources/MultiResolutionTiff/image-scale2res4-lzw.ome.tif]
Series count = 1
Series #0 :
	Resolutions = 4
		sizeX[0] = 1608
		sizeX[1] = 1608
		sizeX[2] = 1608
		sizeX[3] = 1608
	Image count = 1
	RGB = false (1) 
	Interleaved = false
	Indexed = false (false color)
	Width = 1608
	Height = 1608
	SizeZ = 1
	SizeT = 1
	SizeC = 1
	Tile size = 1608 x 326
	Thumbnail size = 128 x 128
	Endianness = motorola (big)
	Dimension order = XYCZT (certain)
	Pixel type = uint16
	Valid bits per pixel = 16
	Metadata complete = true
	Thumbnail series = false
	-----
	Plane #0 <=> Z 0, C 0, T 0


Reading global metadata

Reading metadata
```

As reported by the previous command, the four resolutions have the same dimensions (rather than being downsampled by a factor 2). This is also an issue in our `GeneratePyramidResolutions` example and we'll need to look into it to fix the issue.